### PR TITLE
「kaminari を使ってページング処理を実装する」の課題としてページング処理を実装しました。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,5 @@ group :test do
 end
 
 gem 'carrierwave'
+
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,18 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -277,6 +289,7 @@ DEPENDENCIES
   i18n_generators
   importmap-rails
   jbuilder
+  kaminari
   puma (~> 5.0)
   rails (~> 7.0.4)
   rubocop-fjord

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,7 +5,7 @@ class BooksController < ApplicationController
 
   # GET /books or /books.json
   def index
-    @books = Book.all
+    @books = Book.order(:id).page(params[:page]).per(1)
   end
 
   # GET /books/1 or /books/1.json

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -16,3 +16,5 @@
 <nav class="page-nav">
   <%= link_to t('views.common.new', name: Book.model_name.human.downcase), new_book_path %>
 </nav>
+
+<%= paginate @books %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 10
+  # config.default_per_page = 25
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."


### PR DESCRIPTION
[kaminari を使ってページング処理を実装する](https://bootcamp.fjord.jp/practices/134)の課題としてfjord_books_app-2023にページング処理を実装しました。
画面のスクリーンショットは[提出フォーム](https://bootcamp.fjord.jp/products/16896)に記載してあります。
レビューお願い致します。

- ページングの表示で複数の番号が表示できることを確認したかったのですが、本の件数が3つしかないため、1ページあたりの表示件数を1としています。
- 表示のorderはidの昇順で設定しています。
- kaminariの"First"や"Last"のような表示を日本語化できています。